### PR TITLE
Add dockerfile for bindgen

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ The generate/bindgen.sh can be called from the root directory to create the vari
 src/binary. The version of esp-idf used should match the version of the binary blobs in the 
 esp32-wifi-lib sub-repository. (Currently version v4.1 of the esp-idf is used.)
 
+To run the generate/bindgen.sh in Docker:
+```cmd
+docker build -t esp32-wifi-generate -f ./generate/Dockerfile .
+docker run --mount "type=bind,source=$(pwd)/src,target=/esp32-wifi/src/" esp32-wifi-generate
+```
+
 ## License
 
 Licensed under either of

--- a/generate/Dockerfile
+++ b/generate/Dockerfile
@@ -1,0 +1,40 @@
+FROM espressif/idf:v4.1
+
+ARG toolchain=nightly-2020-10-09
+ARG xtensalink="https://github.com/espressif/crosstool-NG/releases/download/esp-2020r3/xtensa-esp32-elf-gcc8_4_0-esp-2020r3-linux-amd64.tar.gz"
+
+RUN apt-get update -y && apt-get install -y build-essential cmake clang-6.0
+
+# Init rust-xtensa
+RUN git clone --depth 1 https://github.com/MabezDev/rust-xtensa /rust-xtensa
+RUN cd rust-xtensa && \
+  ./configure --experimental-targets=Xtensa && \
+  ./x.py build --stage 2
+
+ENV CUSTOM_RUSTC=/rust-xtensa
+ENV RUST_BACKTRACE=1
+ENV XARGO_RUST_SRC=$CUSTOM_RUSTC/library
+ENV RUSTC=$CUSTOM_RUSTC/build/x86_64-unknown-linux-gnu/stage2/bin/rustc
+ENV RUSTDOC=$CUSTOM_RUSTC/build/x86_64-unknown-linux-gnu/stage2/bin/rustdoc
+
+# Init xtensa-esp32-elf-gcc8
+RUN wget ${xtensalink} -O /tmp/xtensa-esp32-elf-gcc8.tar.gz && \
+  mkdir -p /esp && \
+  tar -xzf "/tmp/xtensa-esp32-elf-gcc8.tar.gz" -C /esp && \
+  rm "/tmp/xtensa-esp32-elf-gcc8.tar.gz"
+ENV PATH="$PATH:/esp/xtensa-esp32-elf/bin"
+
+# Init bindgen
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup toolchain install ${toolchain} --allow-downgrade --profile minimal --component rustfmt
+RUN cargo install bindgen
+
+ADD ./esp32-wifi-lib /esp32-wifi/esp32-wifi-lib/
+ADD ./generate /esp32-wifi/generate/
+
+WORKDIR /esp32-wifi
+
+ENTRYPOINT ["/esp32-wifi/generate/bindgen.sh"]
+
+


### PR DESCRIPTION
Wanted to rerun the bindgen.sh script and had some issues with missing libraries on my system. I think this might also be valuable in the future when a new esp-idf version is released. It might also make sense to mount those two folders on docker run instead of adding them:

```
ADD ./esp32-wifi-lib /esp32-wifi/esp32-wifi-lib/
ADD ./generate /esp32-wifi/generate/
```